### PR TITLE
Remove `is_loopback` field

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "mac_address",
-    .version = "0.1.0",
+    .version = "0.1.1",
     .minimum_zig_version = "0.12.0",
     .dependencies = .{
         .zigwin32 = .{

--- a/lib/MacAddress.zig
+++ b/lib/MacAddress.zig
@@ -1,6 +1,3 @@
-/// Determines whether MAC address belongs to a loopback device
-is_loopback: bool,
-
 /// Individual bytes of the MAC address.
 data: [6]u8,
 

--- a/lib/MacAddress.zig
+++ b/lib/MacAddress.zig
@@ -10,11 +10,6 @@ pub const FormatError = error{
 };
 
 /// Parse a string into a `MacAddress`.
-///
-/// The `is_loopback` field is set to `false` but does not mean the parsed
-/// value is not a loopback interface. This function does not make any
-/// syscalls, so it knows nothing about the interface that's identified by the
-/// value -- it's purely for display.
 pub fn parse(buf: []const u8) !Self {
     var data: [6]u8 = undefined;
     var iter = std.mem.tokenizeScalar(u8, buf, ':');
@@ -28,7 +23,6 @@ pub fn parse(buf: []const u8) !Self {
     if (i < 6) return ParseError.InvalidInput;
 
     return Self{
-        .is_loopback = false,
         .data = data,
     };
 }
@@ -78,7 +72,7 @@ const MAC_STR_LEN = 17;
 
 test "parse_success" {
     const str = "00:11:22:33:44:55";
-    const expected = Self{ .is_loopback = false, .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
+    const expected = Self{ .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
     const addr = try Self.parse(str);
 
     try testing.expect(std.meta.eql(expected, addr));
@@ -110,7 +104,7 @@ test "parse_error_malformed2" {
 }
 
 test "format_buf_success" {
-    const addr = Self{ .is_loopback = false, .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
+    const addr = Self{ .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
     const expected = "00:11:22:33:44:55";
     var buf: [MAC_STR_LEN]u8 = undefined;
 
@@ -118,14 +112,14 @@ test "format_buf_success" {
 }
 
 test "format_buf_too_small" {
-    const addr = Self{ .is_loopback = false, .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
+    const addr = Self{ .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
     var buf: [16]u8 = undefined;
 
     try testing.expectError(FormatError.NoSpaceLeft, addr.formatBuf(&buf));
 }
 
 test "format_alloc_success" {
-    const addr = Self{ .is_loopback = false, .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
+    const addr = Self{ .data = .{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 } };
     const expected = "00:11:22:33:44:55";
     const buf = try addr.formatAlloc(testing.allocator);
     defer testing.allocator.free(buf);

--- a/lib/linux.zig
+++ b/lib/linux.zig
@@ -14,7 +14,7 @@
 /// The caller is owns the returned memory.
 pub fn getAll(allocator: mem.Allocator) ![]MacAddress {
     var addrs = std.ArrayList(MacAddress).init(allocator);
-    var iter = try IfIterator.initAlloc(allocator);
+    var iter = try IfIterator.initAlloc(allocator, .{});
     defer iter.deinit();
 
     while (try iter.next()) |addr| {
@@ -33,14 +33,10 @@ pub fn getAll(allocator: mem.Allocator) ![]MacAddress {
 /// The returned memory is stack allocated and returned by value; the caller
 /// need not free anything.
 pub fn getFirstNoLoopback(allocator: mem.Allocator) !MacAddress {
-    var iter = try IfIterator.initAlloc(allocator);
+    var iter = try IfIterator.initAlloc(allocator, .{ .skip_loopback = true });
     defer iter.deinit();
 
     while (try iter.next()) |addr| {
-        if (addr.is_loopback) {
-            continue;
-        }
-
         return addr;
     }
 
@@ -63,8 +59,13 @@ const IfIterator = struct {
     buffer: []ifreq,
     index: usize,
     sock_fd: i32,
+    iterator_options: IteratorOptions,
 
-    pub fn initAlloc(allocator: mem.Allocator) !IfIterator {
+    pub const IteratorOptions = struct {
+        skip_loopback: bool = false,
+    };
+
+    pub fn initAlloc(allocator: mem.Allocator, iterator_options: IteratorOptions) !IfIterator {
         const sock = linux.socket(linux.AF.INET, linux.SOCK.DGRAM, linux.IPPROTO.IP);
         const sock_fd = if (posix.errno(sock) == .SUCCESS)
             @as(linux.fd_t, @intCast(sock))
@@ -87,6 +88,7 @@ const IfIterator = struct {
             .buffer = elems,
             .index = 0,
             .sock_fd = sock_fd,
+            .iterator_options = iterator_options,
         };
     }
 
@@ -101,13 +103,22 @@ const IfIterator = struct {
         }
 
         const elem = &self.buffer[self.index];
-        var addr = mem.zeroes(MacAddress);
+
+        std.debug.print("if: {s}\n", .{elem.ifrn.name});
 
         ioctlReq(self.sock_fd, SIOCGIFFLAGS, elem) catch return MacAddressError.OsError;
-        addr.is_loopback = elem.ifru.flags & IFF_LOOPBACK != 0;
+        const is_loopback = elem.ifru.flags & IFF_LOOPBACK != 0;
+
+        if (self.iterator_options.skip_loopback and is_loopback) {
+            self.index += 1;
+            return self.next();
+        }
 
         ioctlReq(self.sock_fd, SIOCGIFHWADDR, elem) catch return MacAddressError.OsError;
-        addr.data = elem.ifru.hwaddr.data[0..6].*;
+        const hwaddr = elem.ifru.hwaddr.data[0..6].*;
+
+        var addr = mem.zeroes(MacAddress);
+        addr.data = hwaddr;
 
         self.index += 1;
 

--- a/lib/linux.zig
+++ b/lib/linux.zig
@@ -104,8 +104,6 @@ const IfIterator = struct {
 
         const elem = &self.buffer[self.index];
 
-        std.debug.print("if: {s}\n", .{elem.ifrn.name});
-
         ioctlReq(self.sock_fd, SIOCGIFFLAGS, elem) catch return MacAddressError.OsError;
         const is_loopback = elem.ifru.flags & IFF_LOOPBACK != 0;
 

--- a/lib/root.zig
+++ b/lib/root.zig
@@ -37,6 +37,5 @@ test "get_all" {
 test "get_first_no_loopback" {
     const addr = try getFirstNoLoopback(testing.allocator);
 
-    try testing.expectEqual(false, addr.is_loopback);
-    try testing.expect(!std.mem.eql(u8, &addr.data, &.{ 0, 0, 0, 0, 0, 0 }));
+    try testing.expectEqualSlices(u8, &addr.data, &.{ 0, 0, 0, 0, 0, 0 });
 }

--- a/lib/root.zig
+++ b/lib/root.zig
@@ -37,5 +37,5 @@ test "get_all" {
 test "get_first_no_loopback" {
     const addr = try getFirstNoLoopback(testing.allocator);
 
-    try testing.expectEqualSlices(u8, &addr.data, &.{ 0, 0, 0, 0, 0, 0 });
+    try testing.expect(std.mem.indexOfDiff(u8, &addr.data, &.{ 0, 0, 0, 0, 0, 0 }) != null);
 }

--- a/lib/windows.zig
+++ b/lib/windows.zig
@@ -23,7 +23,6 @@ pub fn getAll(allocator: mem.Allocator) ![]MacAddress {
     while (node) |adapter| : (node = node.?.Next) {
         try addrs.append(MacAddress{
             .data = adapter.PhysicalAddress[0..6].*,
-            .is_loopback = if (adapter.IfType == MIB_IF_TYPE_LOOPBACK) true else false,
         });
     }
 
@@ -52,7 +51,6 @@ pub fn getFirstNoLoopback(allocator: mem.Allocator) !MacAddress {
         if (adapter.IfType != MIB_IF_TYPE_LOOPBACK) {
             return MacAddress{
                 .data = adapter.PhysicalAddress[0..6].*,
-                .is_loopback = false,
             };
         }
     }

--- a/lib/windows.zig
+++ b/lib/windows.zig
@@ -73,7 +73,3 @@ const GetAdaptersAddresses = ip_helper.GetAdaptersAddresses;
 const MIB_IF_TYPE_LOOPBACK = ip_helper.MIB_IF_TYPE_LOOPBACK;
 const MacAddress = @import("MacAddress.zig");
 const MacAddressError = @import("errors.zig").MacAddressError;
-
-const AdapterOptions = struct {
-    exclude_loopback: bool = false,
-};


### PR DESCRIPTION
Closes #8.

As stated in the issue, the `is_loopback` field was an internal implementation detail that leaked into the public interface.